### PR TITLE
Add PROTECT to fix rchk warnings

### DIFF
--- a/src/qrng.c
+++ b/src/qrng.c
@@ -27,9 +27,10 @@ SEXP qrng_alloc(SEXP type, SEXP dimension)
 	default:
 		error("unknown QRNG type");
 	};
-	dimension = AS_INTEGER(dimension);
+	PROTECT(dimension = AS_INTEGER(dimension));
 	result = R_MakeExternalPtr(gsl_qrng_alloc(T, (unsigned int)asInteger(dimension)),
 				   dimension, R_NilValue);
+	UNPROTECT(1);
 	R_RegisterCFinalizer(result, cleanup);
 	return result;
 }  
@@ -42,7 +43,8 @@ SEXP qrng_clone(SEXP r)
 	if (TYPEOF(r) != EXTPTRSXP || !(gen = (gsl_qrng*)EXTPTR_PTR(r))) 
 		error("not a QRNG generator");
 	result = R_MakeExternalPtr(gsl_qrng_clone(gen),
-				   duplicate(EXTPTR_TAG(r)), R_NilValue);
+				   PROTECT(duplicate(EXTPTR_TAG(r))), R_NilValue);
+	UNPROTECT(1);
 	R_RegisterCFinalizer(result, cleanup);
 	return result;
 }

--- a/src/rng.c
+++ b/src/rng.c
@@ -96,7 +96,8 @@ SEXP rng_clone(SEXP r) {
 	gen = get_rng_from_sexp(r);
 	
 	result = R_MakeExternalPtr(gsl_rng_clone(gen),
-				   duplicate(EXTPTR_TAG(r)), R_NilValue);
+				   PROTECT(duplicate(EXTPTR_TAG(r))), R_NilValue);
+	UNPROTECT(1);
 	R_RegisterCFinalizer(result, rng_cleanup);
 
 	return result;


### PR DESCRIPTION
I haven't run this against rchk; I don't think I can install that on my system.  I did run the regular R CMD check --as-cran.

I believe r-hub has an rchk platform; you might want to run there.